### PR TITLE
Added support for model @properties in 'project'

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Allows to eagerly load specific relations by name.
     
     Note that no relations are loaded implicitly: you need to specify them in a `'join'`.
 
+    Important note: if you using join with query(dict syntax) and use projection for the main entity. It could be necessary to add forein key to the projection.
+
 ### Aggregate Operation
 
 Allows to fetch aggregated values with the help of aggregation functions.

--- a/mongosql/__init__.py
+++ b/mongosql/__init__.py
@@ -1,4 +1,4 @@
-from .model import MongoModel, MongoJsonSerializableBase
+from .model import MongoModel
 from .query import MongoQuery
 
 from .sa import MongoSqlBase

--- a/mongosql/__init__.py
+++ b/mongosql/__init__.py
@@ -1,4 +1,4 @@
-from .model import MongoModel
+from .model import MongoModel, MongoJsonSerializableBase
 from .query import MongoQuery
 
 from .sa import MongoSqlBase

--- a/mongosql/crud.py
+++ b/mongosql/crud.py
@@ -294,8 +294,7 @@ class CrudViewMixin(object):
         sql_query = self._mquery(query_obj, *filter, **filter_by).end()
 
         instance = sql_query.one()
-        if getattr(sql_query, 'mongo_project_properies', None):
-            instance.mongo_project_properies = sql_query.mongo_project_properies
+        instance.mongo_project_properties = sql_query.mongo_project_properties
         return instance
 
     def _save_hook(self, new, prev=None):
@@ -329,10 +328,10 @@ class CrudViewMixin(object):
         # Convert KeyedTuples to dicts (when aggregating)
         if query_obj and 'aggregate' in query_obj:
             return [dict(zip(row.keys(), row)) for row in res]
-        if getattr(sql_query, 'mongo_project_properies', None):
+        if getattr(sql_query, 'mongo_project_properties', None):
             result = []
             for instance in res:
-                instance.mongo_project_properies = sql_query.mongo_project_properies
+                instance.mongo_project_properties = sql_query.mongo_project_properties
                 result.append(instance)
             return result
 

--- a/mongosql/model.py
+++ b/mongosql/model.py
@@ -2,7 +2,6 @@ from sqlalchemy import inspect, event
 
 from .statements import MongoProjection, MongoSort, MongoGroup, MongoCriteria, MongoJoin, MongoAggregate
 from .bag import ModelPropertyBags
-from flask.ext.jsontools import JsonSerializableBase
 
 
 class MongoModel(object):
@@ -179,19 +178,3 @@ class MongoModel(object):
         return MongoAggregate(agg_spec)(self)
 
     #endregion
-
-
-class MongoJsonSerializableBase(JsonSerializableBase):
-    """ Declarative Base mixin to allow objects serialization
-
-        Defines interfaces utilized by :cls:ApiJSONEncoder
-    """
-    mongo_project_properies = None
-
-    def __json__(self, exluded_keys=set()):
-        data = super(MongoJsonSerializableBase, self).__json__(exluded_keys)
-        if self.mongo_project_properies:
-            for name, include in self.mongo_project_properies.items():
-                if include:
-                    data[name] = getattr(self, name)
-        return data

--- a/mongosql/model.py
+++ b/mongosql/model.py
@@ -1,7 +1,8 @@
-from sqlalchemy import inspect
+from sqlalchemy import inspect, event
 
 from .statements import MongoProjection, MongoSort, MongoGroup, MongoCriteria, MongoJoin, MongoAggregate
 from .bag import ModelPropertyBags
+from flask.ext.jsontools import JsonSerializableBase
 
 
 class MongoModel(object):
@@ -178,3 +179,19 @@ class MongoModel(object):
         return MongoAggregate(agg_spec)(self)
 
     #endregion
+
+
+class MongoJsonSerializableBase(JsonSerializableBase):
+    """ Declarative Base mixin to allow objects serialization
+
+        Defines interfaces utilized by :cls:ApiJSONEncoder
+    """
+    mongo_project_properies = None
+
+    def __json__(self, exluded_keys=set()):
+        data = super(MongoJsonSerializableBase, self).__json__(exluded_keys)
+        if self.mongo_project_properies:
+            for name, include in self.mongo_project_properies.items():
+                if include:
+                    data[name] = getattr(self, name)
+        return data

--- a/mongosql/query.py
+++ b/mongosql/query.py
@@ -59,10 +59,11 @@ class MongoQuery(object):
 
     def project(self, projection):
         """ Apply a projection to the query """
-        p = self._model.project(projection, as_relation=self._as_relation)
+        p, model_properties = self._model.project(projection, as_relation=self._as_relation)
         if self._model.model.__name__ == 'User':
             assert 1
         self._query = self._query.options(p)
+        self._query.mongo_project_properies = model_properties
         return self
 
     def sort(self, sort_spec):

--- a/mongosql/statements.py
+++ b/mongosql/statements.py
@@ -353,7 +353,7 @@ class MongoCriteria(object):
 
 
 class _MongoJoinParams(object):
-    def __init__(self, options, relationship=None, target_model=None, query=None):
+    def __init__(self, options, relationship=None, target_model=None, query=None, relname=None):
         """ Values for joins
         :param options: Additional query options
         :type options: Sequence[sqlalchemy.orm.Load]
@@ -368,6 +368,7 @@ class _MongoJoinParams(object):
         self.relationship = relationship
         self.target_model = target_model
         self.query = query
+        self.relname = relname
 
 
 class MongoJoin(object):
@@ -428,7 +429,8 @@ class MongoJoin(object):
                     [as_relation.contains_eager(rel)],
                     rel,
                     target_model,
-                    query
+                    query,
+                    relname
                 ))
 
         # lazyload() on all other relations

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mongosql',
-    version='1.2.4-0',
+    version='1.3.0-0',
     author='Mark Vartanyan',
     author_email='kolypto@gmail.com',
 

--- a/tests/01-statements-test.py
+++ b/tests/01-statements-test.py
@@ -245,6 +245,15 @@ class StatementsTest(unittest.TestCase):
         mq = m.mongoquery(Query([models.User]))
         self.assertRaises(AssertionError, mq.join, ('???'))
 
+        # Join with limit, should use FROM (SELECT...)
+        mq = models.Article.mongoquery(Query([models.Article]))
+        mq = mq.query(project=['id'], outerjoin={'comments': {'project': ['id']}}, limit=2)
+        q = mq.end()
+        qs = q2sql(q)
+        self.assertIn('SELECT anon_1.a_id AS anon_1_a_id, c.id AS c_id', qs)
+        self.assertIn('FROM (SELECT a.id AS a_id', qs)
+        self.assertIn('LIMIT 2) AS anon_1 LEFT OUTER JOIN c ON anon_1.a_id = c.aid', qs)
+
     def test_aggregate(self):
         """ Test aggregate() """
         m = models.User

--- a/tests/03-crud-test.py
+++ b/tests/03-crud-test.py
@@ -235,3 +235,37 @@ class CrudTest(unittest.TestCase):
 
     def test_404(self):
         """ Try accessing entities that do not exist """
+
+    def test_property_project(self):
+        """ Test project of @property """
+
+        # Simple get
+        with self.app.test_client() as c:
+            rv = c.get('/article/30', json={
+                'query': {
+                    'project': ['uid', 'calculated'],
+                }
+            })
+            self.assertEqual(rv['article'], {
+                'id': 30, 'uid': 3, 'calculated': 5
+            })
+            rv = c.get('/article/', json={
+                'query': {
+                    'project': ['uid', 'calculated'],
+                }
+            })
+            self.assertEqual(rv['articles'], [
+                # 2 items
+                # sort: id-
+                {'id': 30, 'uid': 3, 'calculated': 5},
+                {'id': 21, 'uid': 2, 'calculated': 4}
+            ])
+            try:
+                rv = c.get('/article/', json={
+                    'query': {
+                        'project': ['uid', 'no_such_property'],
+                    }
+                })
+                assert False, 'Should throw an exception'
+            except:
+                pass

--- a/tests/03-crud-test.py
+++ b/tests/03-crud-test.py
@@ -184,14 +184,6 @@ class CrudTest(unittest.TestCase):
 
         self.db.close()  # Reset session and its cache
 
-        # Query get: try banned relation
-        with self.app.test_client() as c:
-            self.assertRaises(AssertionError, c.get, '/article/30', json={
-                'query': {
-                    'join': ['comments'],
-                }
-            })
-
     def test_update(self):
         """ Test update() """
 
@@ -260,6 +252,21 @@ class CrudTest(unittest.TestCase):
                 {'id': 30, 'uid': 3, 'calculated': 5},
                 {'id': 21, 'uid': 2, 'calculated': 4}
             ])
+            # Propjection for join
+            rv = c.get('/article/20', json={
+                'query': {
+                    'project': ['id'],
+                    'join': {'comments': {
+                        'project': ['id', 'comment_calc'],
+                    }}}
+            })
+            self.assertEqual(rv['article'], {
+                'id': 20,
+                'comments': [
+                    {'comment_calc': u'ONE', 'id': 7},
+                    {'comment_calc': u'TWO', 'id': 8}]
+            })
+
             try:
                 rv = c.get('/article/', json={
                     'query': {

--- a/tests/03-crud-test.py
+++ b/tests/03-crud-test.py
@@ -164,7 +164,7 @@ class CrudTest(unittest.TestCase):
         with self.app.test_client() as c:
             rv = c.get('/article/30', json={
                 'query': {
-                    'project': ['id'],
+                    'project': ['id', 'uid'],
                     'join': {
                         'user': {
                             'project': ['name'],
@@ -176,6 +176,7 @@ class CrudTest(unittest.TestCase):
             })
             self.assertEqual(rv['article'], {
                 'id': 30,
+                'uid': 3,
                 'user': {
                     'id': 3, 'name': 'c',
                     'comments': [{'id': 3, 'uid': 3, 'aid': 10, 'text': '10-c', }]

--- a/tests/crud_view.py
+++ b/tests/crud_view.py
@@ -11,7 +11,7 @@ class ArticlesView(RestfulView, CrudViewMixin):
     # We're strict, yeah
     crudhelper = StrictCrudHelper(models.Article,
         ro_fields=('id', 'uid',),
-        allow_relations=('user', 'user.comments'),
+        allow_relations=('user', 'user.comments', 'comments'),
         query_defaults={
             'sort': ['id-'],
         },

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,11 +8,9 @@ from sqlalchemy.sql.schema import ForeignKey
 
 from sqlalchemy.dialects import postgresql as pg
 
-from mongosql import MongoSqlBase
-from flask.ext.jsontools import JsonSerializableBase
+from mongosql import MongoSqlBase, MongoJsonSerializableBase
 
-
-Base = declarative_base(cls=(MongoSqlBase, JsonSerializableBase))
+Base = declarative_base(cls=(MongoSqlBase, MongoJsonSerializableBase))
 
 
 class User(Base):
@@ -34,6 +32,9 @@ class Article(Base):
 
     user = relationship(User, backref=backref('articles'))
 
+    @property
+    def calculated(self):
+        return len(self.title) + self.uid
 
 class Comment(Base):
     __tablename__ = 'c'

--- a/tests/models.py
+++ b/tests/models.py
@@ -102,7 +102,7 @@ def init_database():
     """ Init DB
     :rtype: (sqlalchemy.engine.Engine, sqlalchemy.orm.Session)
     """
-    engine = create_engine('postgresql://postgres:postgres@localhost/test_mongosql', convert_unicode=True)
+    engine = create_engine('postgresql://postgres:postgres@localhost/test_mongosql', convert_unicode=True, echo=False)
     Session = sessionmaker(autocommit=True, autoflush=True, bind=engine)
     return engine, Session
 


### PR DESCRIPTION
Added ability to add not just Columns, but any other model properties
to the projection query param. But model should check its
mongo_project_properies property in __json__ method.
And more, mongosql just adds this additional projection items to the
sqlalchemy query to the mongo_project_properies attribute.