### PR TITLE
#5687 filter by relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,6 @@ Filter by the relations fields.
 * `{filter: {address.zip: 1234}}` - filter by address relation zip field, but return all
 adresses if joined with address.
 
-*! Be careful with multiple such expressions (e.g. {address.zip: 1234, address.house: 12}) as this produce non-obvious queries!*
-
 ### Join Operation
 
 Allows to eagerly load specific relations by name.

--- a/tests/01-statements-test.py
+++ b/tests/01-statements-test.py
@@ -343,3 +343,10 @@ class StatementsTest(unittest.TestCase):
         q = mq.end()
         qs = q2sql(q)
         self.assertIn("WHERE EXISTS (SELECT 1 \nFROM u \nWHERE u.id = c.uid AND u.id > 2)", qs)
+
+        # Dotted multiple filter for same relation
+        mq = models.Comment.mongoquery(Query([models.Comment]))
+        mq = mq.query(filter={'user.id': {'$gt': 2}, 'user.age': {'$gt': 18}})
+        q = mq.end()
+        qs = q2sql(q)
+        self.assertIn("WHERE EXISTS (SELECT 1 \nFROM u \nWHERE u.id = c.uid AND u.id > 2 AND u.age > 18)", qs)

--- a/tests/03-crud-test.py
+++ b/tests/03-crud-test.py
@@ -224,7 +224,7 @@ class CrudTest(unittest.TestCase):
                 'data': {'o': {'a': True}, 'rating': 5},
 
                 # FIXME: for some reason, deleted entity has 'comments' relationships loaded! Why? They shouldn't be here
-                'comments': [{'aid': None, 'id': 1, 'text': '10-a', 'uid': 1},{'aid': None, 'id': 2, 'text': '10-b', 'uid': 2},{'aid': None, 'id': 3, 'text': '10-c', 'uid': 3}],
+                'comments': [{'aid': None, 'id': 100, 'text': '10-a', 'uid': 1},{'aid': None, 'id': 101, 'text': '10-b', 'uid': 2},{'aid': None, 'id': 102, 'text': '10-c', 'uid': 3}],
             })
 
             self.db.close()


### PR DESCRIPTION
Before it filter={'user.id': {'$gt': 2}, 'user.age': {'$gt': 18}} produced ,
"WHERE EXISTS (SELECT 1 FROM u WHERE u.id = c.uid AND u.id > 2) AND
EXISTS (SELECT 1 FROM u WHERE u.id = c.uid AND u.age > 18)". Which
query is not what user usually expected.

Now mongosql produce more logical query -
"WHERE EXISTS (SELECT 1 FROM u WHERE u.id = c.uid AND u.id > 2 AND u.age > 18)"