### PR TITLE
Removed _no_joindefaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mongosql',
-    version='1.3.2-0',
+    version='1.3.3-0',
     author='Mark Vartanyan',
     author_email='kolypto@gmail.com',
 

--- a/tests/01-statements-test.py
+++ b/tests/01-statements-test.py
@@ -293,8 +293,8 @@ class StatementsTest(unittest.TestCase):
             self.assertTrue(qs.startswith(expected_starts), '{!r} should start with {!r}'.format(qs, expected_starts))
 
         # Empty
-        test_aggregate(None, 'SELECT u.id AS u_id \nFROM')
-        test_aggregate({},   'SELECT u.id AS u_id \nFROM')
+        test_aggregate(None, 'SELECT u.id \nFROM')
+        test_aggregate({},   'SELECT u.id \nFROM')
 
         # $func(column)
         test_aggregate({ 'max_age': {'$max': 'age'} }, 'SELECT max(u.age) AS max_age \nFROM')


### PR DESCRIPTION
  Adding join(()) to each query take a lot of time, especially
when we have many nested queries (e.g. join with multiple queries).
Removing this join cause time reduction from 0.8 sec to 0.3 sec for
query with 3 joins. This time is spent inside SQLalchemy when applying
all this lazyload options. We could use explicit 'join': [] in queries
if we need.
  And I am not sure that it worked correct. So for the performance and
more clean code, we should remove this.